### PR TITLE
Fix ISSN normalization

### DIFF
--- a/src/main/java/de/gwdg/metadataqa/marc/definition/general/validator/ISSNValidator.java
+++ b/src/main/java/de/gwdg/metadataqa/marc/definition/general/validator/ISSNValidator.java
@@ -73,7 +73,7 @@ public class ISSNValidator implements SubfieldValidator {
 			// .replaceAll(" ", "")
 			// .replaceAll("[ :-]", "")
 			.replaceAll(" \\(ISSN\\)$", "")
-      .replaceAll("[\\s;:-]+$", "")
+      			.replaceAll("[\\s;:-]+$", "")
 			.trim();
 		return value;
 	}

--- a/src/main/java/de/gwdg/metadataqa/marc/definition/general/validator/ISSNValidator.java
+++ b/src/main/java/de/gwdg/metadataqa/marc/definition/general/validator/ISSNValidator.java
@@ -73,6 +73,7 @@ public class ISSNValidator implements SubfieldValidator {
 			// .replaceAll(" ", "")
 			// .replaceAll("[ :-]", "")
 			.replaceAll(" \\(ISSN\\)$", "")
+      .replaceAll("[\\s;:-]+$", "")
 			.trim();
 		return value;
 	}

--- a/src/test/java/de/gwdg/metadataqa/marc/definition/general/validator/ISSNValidatorTest.java
+++ b/src/test/java/de/gwdg/metadataqa/marc/definition/general/validator/ISSNValidatorTest.java
@@ -54,5 +54,23 @@ public class ISSNValidatorTest {
 		assertEquals(0, response.getValidationErrors().size());
 	}
 
+ 	@Test
+	public void testNormalization() {
+		MarcRecord record = new MarcRecord("test");
+		DataField field = new DataField(Tag411.getInstance(), " ", " ", "x", "0024-9319 ;");
+		field.setRecord(record);
+		MarcSubfield subfield = field.getSubfield("x").get(0);
+		ValidatorResponse response = subfield.getDefinition().getValidator().isValid(subfield);
+		assertTrue(response.isValid());
+		assertEquals(0, response.getValidationErrors().size());
+
+		DataField fieldWithText = new DataField(Tag411.getInstance(), " ", " ", "x", "1040-0400 (ISSN)");
+		fieldWithText.setRecord(record);
+		subfield = fieldWithText.getSubfield("x").get(0);
+		response = subfield.getDefinition().getValidator().isValid(subfield);
+		assertTrue(response.isValid());
+		assertEquals(0, response.getValidationErrors().size());
+	}
+
 	// TODO test it: "1572-9001 (ESSN), 1040-0400 (ISSN). -"
 }


### PR DESCRIPTION
Validation of ISSN codes failed previously, if the subfield contained trailing punctuation. We received errors like this:

```
490$x: invalid ISSN ''1798-7105 ;' is not a valid ISSN value, it does not fit the pattern \d{4}-\d{3}[\dX].' (https://en.wikipedia.org/wiki/International_Standard_Serial_Number)
830$x: invalid ISSN ''1798-7105 ;' is not a valid ISSN value, it does not fit the pattern \d{4}-\d{3}[\dX].' (https://en.wikipedia.org/wiki/International_Standard_Serial_Number)
```
This patch fixes this issue.