### PR TITLE
Use supervisord process manager

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,27 @@
+[unix_http_server]
+file=/tmp/supervisor.sock   ; (the path to the socket file)
+
+[supervisord]
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_backups=10           ; (num of main logfile rotation backups;default 10)
+loglevel=info                ; (log level;default info; others: debug,warn,trace)
+pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+nodaemon=true             ; (start in foreground if true;default false)
+minfds=1024                  ; (min. avail startup file descriptors;default 1024)
+minprocs=200                 ; (min. avail process descriptors;default 200)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[program:httpd]
+command=/usr/sbin/apachectl -D FOREGROUND
+
+[program:solr]
+command=/opt/solr/bin/solr start -f -force


### PR DESCRIPTION
See https://docs.docker.com/config/containers/multi-service_container/

The original entrypoint was actually a command script and the the container did not accept any argument as command.
This did not work before to inspect the container's filesystem:

`docker run --rm -it pkiraly/metadata-qa-marc bash`

It works with this modification but the default command is supervisord which is a small process manager able to handle multiple processes like systemd.