### PR TITLE
Fix locale based number formatting in ShelfReadyFieldsBooksTest

### DIFF
--- a/src/test/java/de/gwdg/metadataqa/marc/analysis/ShelfReadyFieldsBooksTest.java
+++ b/src/test/java/de/gwdg/metadataqa/marc/analysis/ShelfReadyFieldsBooksTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
@@ -25,6 +26,6 @@ public class ShelfReadyFieldsBooksTest {
       count++;
       total += tag.getScore();
     }
-    assertEquals("28.441", String.format("%.3f", total / count));
+    assertEquals("28.441", String.format(Locale.ENGLISH, "%.3f", total / count));
   }
 }


### PR DESCRIPTION
I had hungarian locale setting in my terminal so mvn install did not work because of the failed ShelfReadyFieldsBooksTest.
String.format returned "28,441" instead of "28.441" 
The test must use a specific locale to work for everyone.