### PR TITLE
Add SOLR_HOST variable

### DIFF
--- a/index
+++ b/index
@@ -34,7 +34,7 @@ usage:
                         VISUAL_MATERIALS, COMPUTER_FILES, MIXED_MATERIALS
  -v, --marcVersion <version> MARC version.
                         Possible values: MARC21 (default), OCLC, DNB, GENT, SZTE, FENNICA, UNIMARC
- -i, --ignorableRecords <condition> ignore records from the analysis 
+ -i, --ignorableRecords <condition> ignore records from the analysis
  -h, --help             this help
 EOF
   exit 1
@@ -79,24 +79,26 @@ echo "limit: $limit"
 
 CORE=${DB}_dev
 
-export SOLR=http://localhost:8983/solr/${CORE}
+SOLR_DB_URL="${SOLR_HOST}/solr/${CORE}"
+
+echo "SOLR URL: $SOLR_DB_URL"
 
 if [ "${DELETE}" == "1" ]; then
   echo "Delete records in ${CORE}"
-  curl $SOLR/update -H "Content-type: text/xml" --data-binary '<delete><query>*:*</query></delete>'
+  curl $SOLR_DB_URL/update -H "Content-type: text/xml" --data-binary '<delete><query>*:*</query></delete>'
 fi
 
 echo "Prepare schema"
 prepare_schema $CORE
 
 echo "Start indexing"
-curl $SOLR/update -H "Content-type: text/xml" --data-binary '<commit/>'
+curl $SOLR_DB_URL/update -H "Content-type: text/xml" --data-binary '<commit/>'
 
 cat <<EOT
 running the command
 ---BEGIN
 /usr/bin/java -cp $JAR de.gwdg.metadataqa.marc.cli.MarcToSolr \
-  --solrUrl ${SOLR} \
+  --solrUrl ${SOLR_DB_URL} \
   --solrFieldType $solrFieldType \
   --defaultRecordType $defaultRecordType \
   --marcVersion $marcVersion \
@@ -110,13 +112,13 @@ running the command
 EOT
 
 /usr/bin/java -cp $JAR de.gwdg.metadataqa.marc.cli.MarcToSolr \
-  --solrUrl ${SOLR} --solrFieldType $solrFieldType \
+  --solrUrl ${SOLR_DB_URL} --solrFieldType $solrFieldType \
   --defaultRecordType $defaultRecordType \
   --marcVersion $marcVersion $limit $trimId $marcxml $alephseq $ignorableRecords \
   ${FILE_PATH}/${FILE_MASK}
 
 echo "Start optimizing"
-curl "$SOLR/update?optimize=true" -H 'Content-type: text/xml' --data-binary '<commit/>'
+curl "$SOLR_DB_URL/update?optimize=true" -H 'Content-type: text/xml' --data-binary '<commit/>'
 
 # dev -> production
 echo "Swap ${CORE} to ${DB}"

--- a/prepare-solr
+++ b/prepare-solr
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-PORT=8983
 . ./solr-functions
 
 DB=$1

--- a/solr-functions
+++ b/solr-functions
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+SOLR_HOST=${SOLR_HOST:-http://localhost:${PORT:-8983}}
+
 check_core() {
   LOCAL_CORE=$1
-  LOCAL_URL=$(printf "http://localhost:%s/solr/admin/cores?action=STATUS&core=%s" $PORT $LOCAL_CORE)
+  LOCAL_URL=$(printf "%s/solr/admin/cores?action=STATUS&core=%s" $SOLR_HOST $LOCAL_CORE)
   CORE_EXISTS=$(curl -s "$LOCAL_URL" | jq .status | grep "\"$LOCAL_CORE\":" | grep -c -P '{$')
   # use echo instead of return
   echo $CORE_EXISTS
@@ -10,8 +12,8 @@ check_core() {
 
 create_core() {
   LOCAL_CORE=$1
-  echo "creating Solr index: ${LOCAL_CORE}"
-  curl -s "http://localhost:$PORT/solr/admin/cores?action=CREATE&name=$LOCAL_CORE&configSet=_default"
+  echo "creating Solr index: ${LOCAL_CORE} at $SOLR_HOST"
+  curl -s "$SOLR_HOST/solr/admin/cores?action=CREATE&name=$LOCAL_CORE&configSet=_default"
 }
 
 rename_core() {
@@ -19,7 +21,7 @@ rename_core() {
   LOCAL_TO=$2
 
   echo "rename Solr index: ${LOCAL_FROM} to ${LOCAL_TO}"
-  curl -s "http://localhost:$PORT/solr/admin/cores?action=RENAME&core=${LOCAL_FROM}&other=${LOCAL_TO}"
+  curl -s "$SOLR_HOST/solr/admin/cores?action=RENAME&core=${LOCAL_FROM}&other=${LOCAL_TO}"
 }
 
 swap_cores() {
@@ -27,12 +29,12 @@ swap_cores() {
   LOCAL_TO=$2
 
   echo "Swap Solr indexes ${LOCAL_FROM} and ${LOCAL_TO}"
-  curl -s "http://localhost:$PORT/solr/admin/cores?action=SWAP&core=${LOCAL_FROM}&other=${LOCAL_TO}"
+  curl -s "$SOLR_HOST/solr/admin/cores?action=SWAP&core=${LOCAL_FROM}&other=${LOCAL_TO}"
 }
 
 prepare_schema() {
   LOCAL_CORE=$1
-  SCHEMA_URL=http://localhost:${PORT}/api/cores/${LOCAL_CORE}/schema
+  SCHEMA_URL="${SOLR_HOST}/api/cores/${LOCAL_CORE}/schema"
 
   echo "prepare_schema ${LOCAL_CORE}"
 


### PR DESCRIPTION
Makes it possible to configure metadata-qa-marc to use another Solr host than localhost without touching the scripts.

If not set, it defaults to http://localhost:$PORT for backwards compatibility (with PORT defaulting to 8983 as before).
