### PR TITLE
Rm break in URL, prevented hotlinking in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,8 +1310,7 @@ build.sbt
 libraryDependencies += "de.gwdg.metadataqa" % "metadata-qa-marc" % "0.5.0"
 ```
 
-or you can directly download the jars from [http://repo1.maven.org](http://repo1.maven.
-org/maven2/de/gwdg/metadataqa/metadata-qa-marc/0.5.0/)
+or you can directly download the jars from [http://repo1.maven.org](http://repo1.maven.org/maven2/de/gwdg/metadataqa/metadata-qa-marc/0.5.0/)
 
 ## User interface
 


### PR DESCRIPTION
A hyperlink in the README contains a break in the URL, which causes GitHub to render the hyperlink as malformed text.