### PR TITLE
Adjust K10plus Avram schema

### DIFF
--- a/src/main/resources/pica/avram-k10plus-title.json
+++ b/src/main/resources/pica/avram-k10plus-title.json
@@ -14,7 +14,8 @@
           "repeatable": false
         }
       },
-      "tag": "001A"
+      "tag": "001A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0200"
     },
     "001B": {
       "label": "Kennung und Datum der letzten Änderung",
@@ -37,7 +38,8 @@
           "repeatable": false
         }
       },
-      "tag": "001B"
+      "tag": "001B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0210"
     },
     "001D": {
       "label": "Kennung und Datum der Statusänderung",
@@ -53,7 +55,8 @@
           "repeatable": false
         }
       },
-      "tag": "001D"
+      "tag": "001D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0230"
     },
     "001E": {
       "label": "Kennung und Datum der Löschung",
@@ -76,7 +79,8 @@
           "repeatable": false
         }
       },
-      "tag": "001E"
+      "tag": "001E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0240"
     },
     "001Q": {
       "label": "VAL-Warnungen",
@@ -113,7 +117,8 @@
           "repeatable": false
         }
       },
-      "tag": "001Q"
+      "tag": "001Q",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=000Q"
     },
     "001R": {
       "label": "Validationsmeldung aus WorldCat",
@@ -150,7 +155,8 @@
           "repeatable": false
         }
       },
-      "tag": "001R"
+      "tag": "001R",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=000R"
     },
     "002@": {
       "label": "Bibliografische Gattung und Status",
@@ -166,7 +172,8 @@
           "repeatable": false
         }
       },
-      "tag": "002@"
+      "tag": "002@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0500"
     },
     "002C": {
       "label": "Inhaltstyp",
@@ -191,7 +198,7 @@
         "X": {
           "code": "X",
           "label": "Zuordnung",
-          "modified": "2019-11-28T13:55:47",
+          "modified": "2022-12-20T08:47:07",
           "pica3": "$X",
           "repeatable": false
         },
@@ -210,7 +217,8 @@
           "repeatable": false
         }
       },
-      "tag": "002C"
+      "tag": "002C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0501"
     },
     "002D": {
       "label": "Medientyp",
@@ -235,7 +243,7 @@
         "X": {
           "code": "X",
           "label": "Zuordnung",
-          "modified": "2019-11-28T14:18:00",
+          "modified": "2022-12-20T08:38:45",
           "pica3": "$X",
           "repeatable": false
         },
@@ -254,7 +262,8 @@
           "repeatable": false
         }
       },
-      "tag": "002D"
+      "tag": "002D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0502"
     },
     "002E": {
       "label": "Datenträgertyp",
@@ -279,7 +288,7 @@
         "X": {
           "code": "X",
           "label": "Zuordnung",
-          "modified": "2019-11-28T14:19:32",
+          "modified": "2022-12-20T08:47:41",
           "pica3": "$X",
           "repeatable": false
         },
@@ -298,7 +307,8 @@
           "repeatable": false
         }
       },
-      "tag": "002E"
+      "tag": "002E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0503"
     },
     "003@": {
       "label": "Pica-Produktionsnummer",
@@ -314,7 +324,8 @@
           "repeatable": false
         }
       },
-      "tag": "003@"
+      "tag": "003@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0100"
     },
     "003D": {
       "label": "PPN des umgelenkten GBV- bzw. K10plus-Satzes",
@@ -330,7 +341,8 @@
           "repeatable": false
         }
       },
-      "tag": "003D"
+      "tag": "003D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2119"
     },
     "003O": {
       "label": "OCLC-Nummer",
@@ -367,7 +379,8 @@
           "repeatable": false
         }
       },
-      "tag": "003O"
+      "tag": "003O",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2097"
     },
     "003S": {
       "label": "SWB-Pica-Produktionsnummer",
@@ -383,7 +396,8 @@
           "repeatable": false
         }
       },
-      "tag": "003S"
+      "tag": "003S",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0110"
     },
     "003T": {
       "label": "SWB-OCLC-Nummer",
@@ -413,7 +427,8 @@
           "repeatable": false
         }
       },
-      "tag": "003T"
+      "tag": "003T",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2098"
     },
     "004A": {
       "label": "ISBN",
@@ -436,7 +451,8 @@
           "repeatable": false
         }
       },
-      "tag": "004A"
+      "tag": "004A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2000"
     },
     "004C": {
       "label": "Universal Product Code (UPC)",
@@ -452,7 +468,8 @@
           "repeatable": false
         }
       },
-      "tag": "004C"
+      "tag": "004C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2202"
     },
     "004D": {
       "label": "Formal falsche ISBN",
@@ -475,7 +492,8 @@
           "repeatable": false
         }
       },
-      "tag": "004D"
+      "tag": "004D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2009"
     },
     "004F": {
       "label": "ISMN",
@@ -498,7 +516,8 @@
           "repeatable": false
         }
       },
-      "tag": "004F"
+      "tag": "004F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2020"
     },
     "004I": {
       "label": "Formal falsche ISMN",
@@ -521,7 +540,8 @@
           "repeatable": false
         }
       },
-      "tag": "004I"
+      "tag": "004I",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2029"
     },
     "004J": {
       "label": "ISBN der Sekundärausgabe",
@@ -544,7 +564,8 @@
           "repeatable": false
         }
       },
-      "tag": "004J"
+      "tag": "004J",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2007"
     },
     "004K": {
       "label": "Formal falsche ISBN der Sekundärausgabe",
@@ -567,7 +588,8 @@
           "repeatable": false
         }
       },
-      "tag": "004K"
+      "tag": "004K",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2008"
     },
     "004L": {
       "label": "GTIN (vormals EAN)",
@@ -583,7 +605,8 @@
           "repeatable": false
         }
       },
-      "tag": "004L"
+      "tag": "004L",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2201"
     },
     "004M": {
       "label": "ISRN",
@@ -599,7 +622,8 @@
           "repeatable": false
         }
       },
-      "tag": "004M"
+      "tag": "004M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2027"
     },
     "004P": {
       "label": "ISBN einer Manifestation in anderer/gleicher physischer Form",
@@ -629,11 +653,12 @@
           "repeatable": false
         }
       },
-      "tag": "004P"
+      "tag": "004P",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2003"
     },
     "004R": {
       "label": "Handle",
-      "modified": "2018-02-28T10:40:19",
+      "modified": "2023-01-26T11:49:49",
       "pica3": "2052",
       "repeatable": true,
       "subfields": {
@@ -645,7 +670,8 @@
           "repeatable": false
         }
       },
-      "tag": "004R"
+      "tag": "004R",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2052"
     },
     "004U": {
       "label": "Uniform Resource Name (URN)",
@@ -661,7 +687,8 @@
           "repeatable": false
         }
       },
-      "tag": "004U"
+      "tag": "004U",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2050"
     },
     "004V": {
       "label": "Digital Object Identifier (DOI)",
@@ -677,7 +704,8 @@
           "repeatable": false
         }
       },
-      "tag": "004V"
+      "tag": "004V",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2051"
     },
     "004W": {
       "label": "Digital Object Identifier (DOI) im Druckwerk",
@@ -693,7 +721,8 @@
           "repeatable": false
         }
       },
-      "tag": "004W"
+      "tag": "004W",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2053"
     },
     "005A": {
       "label": "ISSN",
@@ -730,7 +759,8 @@
           "repeatable": true
         }
       },
-      "tag": "005A"
+      "tag": "005A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2010"
     },
     "005B": {
       "label": "Formal falsche ISSN",
@@ -753,7 +783,8 @@
           "repeatable": false
         }
       },
-      "tag": "005B"
+      "tag": "005B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2019"
     },
     "005I": {
       "label": "Autorisierte ISSN",
@@ -790,7 +821,8 @@
           "repeatable": true
         }
       },
-      "tag": "005I"
+      "tag": "005I",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2005"
     },
     "005P": {
       "label": "ISSN paralleler Ausgaben",
@@ -820,7 +852,8 @@
           "repeatable": false
         }
       },
-      "tag": "005P"
+      "tag": "005P",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2013"
     },
     "006A": {
       "label": "LoC-Nummer",
@@ -836,7 +869,8 @@
           "repeatable": false
         }
       },
-      "tag": "006A"
+      "tag": "006A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2040"
     },
     "006B": {
       "label": "BNB-Nummer",
@@ -852,7 +886,8 @@
           "repeatable": false
         }
       },
-      "tag": "006B"
+      "tag": "006B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2030"
     },
     "006G": {
       "label": "DNB-Nummer",
@@ -868,7 +903,8 @@
           "repeatable": false
         }
       },
-      "tag": "006G"
+      "tag": "006G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2065"
     },
     "006L": {
       "label": "Weitere Verbundidentnummern",
@@ -891,7 +927,8 @@
           "repeatable": false
         }
       },
-      "tag": "006L"
+      "tag": "006L",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2112"
     },
     "006M": {
       "label": "VD18-Nummer",
@@ -907,7 +944,8 @@
           "repeatable": false
         }
       },
-      "tag": "006M"
+      "tag": "006M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2192"
     },
     "006N": {
       "label": "Swets-Nummer",
@@ -923,7 +961,8 @@
           "repeatable": false
         }
       },
-      "tag": "006N"
+      "tag": "006N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2185"
     },
     "006S": {
       "label": "SWB-PPN des umgelenkten Satzes",
@@ -939,7 +978,8 @@
           "repeatable": false
         }
       },
-      "tag": "006S"
+      "tag": "006S",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2111"
     },
     "006T": {
       "label": "CIP-Nummer",
@@ -955,7 +995,8 @@
           "repeatable": false
         }
       },
-      "tag": "006T"
+      "tag": "006T",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2100"
     },
     "006U": {
       "label": "WV-Nummer",
@@ -971,7 +1012,8 @@
           "repeatable": false
         }
       },
-      "tag": "006U"
+      "tag": "006U",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2105"
     },
     "006V": {
       "label": "VD16-Nummer",
@@ -994,7 +1036,8 @@
           "repeatable": false
         }
       },
-      "tag": "006V"
+      "tag": "006V",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2190"
     },
     "006W": {
       "label": "VD17-Nummer",
@@ -1010,7 +1053,8 @@
           "repeatable": false
         }
       },
-      "tag": "006W"
+      "tag": "006W",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2191"
     },
     "006X": {
       "label": "Identnummern weiterer Fremddatenlieferanten",
@@ -1047,7 +1091,8 @@
           "repeatable": false
         }
       },
-      "tag": "006X"
+      "tag": "006X",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2113"
     },
     "006Y": {
       "label": "Identnummern (allgemein)",
@@ -1077,7 +1122,8 @@
           "repeatable": false
         }
       },
-      "tag": "006Y"
+      "tag": "006Y",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2199"
     },
     "006Z": {
       "label": "ZDB-Nummer",
@@ -1093,7 +1139,8 @@
           "repeatable": false
         }
       },
-      "tag": "006Z"
+      "tag": "006Z",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2110"
     },
     "007C": {
       "label": "CODEN",
@@ -1109,7 +1156,8 @@
           "repeatable": false
         }
       },
-      "tag": "007C"
+      "tag": "007C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2200"
     },
     "007D": {
       "label": "Verlags-, Produktions- und Bestellnummer",
@@ -1146,7 +1194,8 @@
           "repeatable": false
         }
       },
-      "tag": "007D"
+      "tag": "007D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2230"
     },
     "007G": {
       "label": "Identnummer der erstkatalogisierenden Institution",
@@ -1169,7 +1218,8 @@
           "repeatable": false
         }
       },
-      "tag": "007G"
+      "tag": "007G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2240"
     },
     "007H": {
       "label": "EKI des umgelenkten Satzes",
@@ -1192,7 +1242,8 @@
           "repeatable": false
         }
       },
-      "tag": "007H"
+      "tag": "007H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2241"
     },
     "007P": {
       "label": "Fingerprint",
@@ -1243,7 +1294,8 @@
           "repeatable": false
         }
       },
-      "tag": "007P"
+      "tag": "007P",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2275"
     },
     "007S": {
       "label": "Bibliografische Zitate (Alte Drucke)",
@@ -1287,7 +1339,8 @@
           "repeatable": false
         }
       },
-      "tag": "007S"
+      "tag": "007S",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2277"
     },
     "007Y": {
       "label": "Sonstige Standardnummern",
@@ -1310,7 +1363,8 @@
           "repeatable": false
         }
       },
-      "tag": "007Y"
+      "tag": "007Y",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=2198"
     },
     "008@": {
       "label": "Code für VD18-Redaktion",
@@ -1333,7 +1387,8 @@
           "repeatable": false
         }
       },
-      "tag": "008@"
+      "tag": "008@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0701"
     },
     "009@": {
       "label": "Code zur Selektion und maschinellen Bearbeitung",
@@ -1356,7 +1411,8 @@
           "repeatable": false
         }
       },
-      "tag": "009@"
+      "tag": "009@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0599"
     },
     "009A": {
       "label": "Besitznachweis des reproduzierten Exemplars",
@@ -1393,7 +1449,8 @@
           "repeatable": false
         }
       },
-      "tag": "009A"
+      "tag": "009A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4065"
     },
     "009B": {
       "label": "Besitznachweis für den Master (Reproduktion in anderer physischer Form)",
@@ -1472,7 +1529,8 @@
           "repeatable": false
         }
       },
-      "tag": "009B"
+      "tag": "009B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4066"
     },
     "009Y": {
       "label": "Feld für URL-Checker",
@@ -1502,7 +1560,8 @@
           "repeatable": false
         }
       },
-      "tag": "009Y"
+      "tag": "009Y",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4098"
     },
     "010@": {
       "label": "Sprachcodes",
@@ -1553,7 +1612,8 @@
           "repeatable": true
         }
       },
-      "tag": "010@"
+      "tag": "010@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1500"
     },
     "010E": {
       "label": "Katalogisierungsquelle",
@@ -1583,7 +1643,8 @@
           "repeatable": false
         }
       },
-      "tag": "010E"
+      "tag": "010E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1505"
     },
     "011@": {
       "label": "Erscheinungsdatum/Entstehungsdatum",
@@ -1634,7 +1695,8 @@
           "repeatable": false
         }
       },
-      "tag": "011@"
+      "tag": "011@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1100"
     },
     "011B": {
       "label": "Erscheinungsdatum der Reproduktion",
@@ -1664,7 +1726,8 @@
           "repeatable": false
         }
       },
-      "tag": "011B"
+      "tag": "011B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1109"
     },
     "011F": {
       "label": "Copyright-Datum, Vertriebsdatum, Herstellungsdatum",
@@ -1708,7 +1771,8 @@
           "repeatable": false
         }
       },
-      "tag": "011F"
+      "tag": "011F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1108"
     },
     "013D": {
       "label": "Art des Inhalts",
@@ -1794,7 +1858,8 @@
           "repeatable": true
         }
       },
-      "tag": "013D"
+      "tag": "013D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1131"
     },
     "013E": {
       "label": "Musikalische Ausgabeform",
@@ -1838,7 +1903,8 @@
           "repeatable": false
         }
       },
-      "tag": "013E"
+      "tag": "013E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1132"
     },
     "013F": {
       "label": "Zielgruppe",
@@ -1903,7 +1969,8 @@
           "repeatable": false
         }
       },
-      "tag": "013F"
+      "tag": "013F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1133"
     },
     "013G": {
       "label": "Datenträger",
@@ -1968,7 +2035,8 @@
           "repeatable": false
         }
       },
-      "tag": "013G"
+      "tag": "013G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1130"
     },
     "013H": {
       "label": "Veröffentlichungsart und Inhalt",
@@ -1984,7 +2052,8 @@
           "repeatable": true
         }
       },
-      "tag": "013H"
+      "tag": "013H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1140"
     },
     "016A": {
       "label": "Materialspezifische Codes für elektronische Ressourcen",
@@ -2000,7 +2069,8 @@
           "repeatable": false
         }
       },
-      "tag": "016A"
+      "tag": "016A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1101"
     },
     "016B": {
       "label": "Code für Sammlungen",
@@ -2011,12 +2081,13 @@
         "a": {
           "code": "a",
           "label": "Code",
-          "modified": "2022-10-17T12:12:15",
+          "modified": "2023-01-23T09:29:22",
           "pica3": "",
           "repeatable": true
         }
       },
-      "tag": "016B"
+      "tag": "016B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0575"
     },
     "016E": {
       "label": "Materialspezifische Codes für Mikroformen",
@@ -2032,7 +2103,8 @@
           "repeatable": false
         }
       },
-      "tag": "016E"
+      "tag": "016E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1105"
     },
     "017C": {
       "label": "URL zum Volltext",
@@ -2146,7 +2218,8 @@
           "repeatable": false
         }
       },
-      "tag": "017C"
+      "tag": "017C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4950"
     },
     "017D": {
       "label": "URL in Print-Aufnahme",
@@ -2157,7 +2230,7 @@
         "3": {
           "code": "3",
           "label": "Bezugswerk (Klartext)",
-          "modified": "2021-08-30T14:43:46",
+          "modified": "2022-12-02T09:41:36",
           "pica3": "$3",
           "repeatable": false
         },
@@ -2260,7 +2333,8 @@
           "repeatable": false
         }
       },
-      "tag": "017D"
+      "tag": "017D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4951"
     },
     "017E": {
       "label": "VD17 CGI-Skript",
@@ -2304,7 +2378,8 @@
           "repeatable": true
         }
       },
-      "tag": "017E"
+      "tag": "017E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4958"
     },
     "017F": {
       "label": "Nicht mehr gültige URL",
@@ -2418,7 +2493,8 @@
           "repeatable": false
         }
       },
-      "tag": "017F"
+      "tag": "017F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4959"
     },
     "017G": {
       "label": "URL für Kataloganreicherung",
@@ -2532,7 +2608,8 @@
           "repeatable": false
         }
       },
-      "tag": "017G"
+      "tag": "017G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4960"
     },
     "017H": {
       "label": "URL für sonstige Angaben zur Ressource",
@@ -2646,79 +2723,8 @@
           "repeatable": false
         }
       },
-      "tag": "017H"
-    },
-    "017K": {
-      "label": "Produktsigel Gesamtpaket Das Feld wird nicht mehr belegt.",
-      "modified": "2022-06-30T12:01:47",
-      "pica3": "4970",
-      "repeatable": true,
-      "subfields": {
-        "a": {
-          "code": "a",
-          "label": "Code",
-          "modified": "2019-11-25T09:36:30",
-          "pica3": "",
-          "repeatable": false
-        },
-        "b": {
-          "code": "b",
-          "label": "Lizenzjahr (einzelne Pakete)",
-          "modified": "2021-08-30T16:00:19",
-          "pica3": "$b",
-          "repeatable": false
-        },
-        "c": {
-          "code": "c",
-          "label": "Lizenzzeitraum Intervall, Beginn",
-          "modified": "2019-11-25T09:36:44",
-          "pica3": "$c",
-          "repeatable": false
-        },
-        "d": {
-          "code": "d",
-          "label": "Lizenzzeitraum Intervall, Ende",
-          "modified": "2019-11-25T09:36:58",
-          "pica3": "$d",
-          "repeatable": false
-        },
-        "e": {
-          "code": "e",
-          "label": "Jahresteilpakete / Semesterangaben",
-          "modified": "2022-06-30T11:54:49",
-          "pica3": "$e",
-          "repeatable": false
-        },
-        "i": {
-          "code": "i",
-          "label": "Lizenzinformation vom Verlag",
-          "modified": "2020-02-28T13:59:06",
-          "pica3": "$i",
-          "repeatable": false
-        },
-        "k": {
-          "code": "k",
-          "label": "Lizenzart",
-          "modified": "2022-06-30T11:55:10",
-          "pica3": "$k",
-          "repeatable": false
-        },
-        "p": {
-          "code": "p",
-          "label": "Kennzeichnung zurückgezogener Lizenzen",
-          "modified": "2022-06-30T11:55:28",
-          "pica3": "$p",
-          "repeatable": false
-        },
-        "t": {
-          "code": "t",
-          "label": "Datum der Lieferdatei",
-          "modified": "2022-06-30T11:55:49",
-          "pica3": "$t",
-          "repeatable": false
-        }
-      },
-      "tag": "017K"
+      "tag": "017H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4961"
     },
     "017L": {
       "label": "Produktsigel, Arbeitsfeld für sonstige Produktsigel",
@@ -2771,7 +2777,7 @@
         "k": {
           "code": "k",
           "label": "Lizenzart",
-          "modified": "2020-02-28T14:12:14",
+          "modified": "2022-11-23T09:27:48",
           "pica3": "$k",
           "repeatable": false
         },
@@ -2790,7 +2796,8 @@
           "repeatable": false
         }
       },
-      "tag": "017L"
+      "tag": "017L",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4971"
     },
     "017M": {
       "label": "Rechteinformation",
@@ -2883,7 +2890,8 @@
           "repeatable": false
         }
       },
-      "tag": "017M"
+      "tag": "017M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4980"
     },
     "017R": {
       "label": "Access Status",
@@ -2941,7 +2949,8 @@
           "repeatable": false
         }
       },
-      "tag": "017R"
+      "tag": "017R",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4985"
     },
     "018@": {
       "label": "Code für Erscheinungsfrequenz",
@@ -2957,7 +2966,8 @@
           "repeatable": true
         }
       },
-      "tag": "018@"
+      "tag": "018@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1800"
     },
     "019@": {
       "label": "Code für Erscheinungsland",
@@ -2973,7 +2983,8 @@
           "repeatable": true
         }
       },
-      "tag": "019@"
+      "tag": "019@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1700"
     },
     "020I": {
       "label": "ekz-Annotation",
@@ -2996,7 +3007,8 @@
           "repeatable": false
         }
       },
-      "tag": "020I"
+      "tag": "020I",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5952"
     },
     "020K": {
       "label": "ekz-Rezension",
@@ -3019,7 +3031,8 @@
           "repeatable": false
         }
       },
-      "tag": "020K"
+      "tag": "020K",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5953"
     },
     "021A": {
       "label": "Haupttitel, Titelzusatz, Verantwortlichkeitsangabe",
@@ -3070,7 +3083,8 @@
           "repeatable": false
         }
       },
-      "tag": "021A"
+      "tag": "021A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4000"
     },
     "021C": {
       "label": "Unterreihe",
@@ -3135,7 +3149,8 @@
           "repeatable": false
         }
       },
-      "tag": "021C"
+      "tag": "021C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4005"
     },
     "021G": {
       "label": "Paralleltitel, paralleler Titelzusatz, parallele Verantwortlichkeitsangabe",
@@ -3186,7 +3201,8 @@
           "repeatable": false
         }
       },
-      "tag": "021G"
+      "tag": "021G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4002"
     },
     "021M": {
       "label": "Weitere Titel etc. bei Zusammenstellungen",
@@ -3237,7 +3253,8 @@
           "repeatable": false
         }
       },
-      "tag": "021M"
+      "tag": "021M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4010"
     },
     "021N": {
       "label": "Titelzusätze und Verantwortlichkeitsangabe zur gesamten Vorlage",
@@ -3267,7 +3284,8 @@
           "repeatable": false
         }
       },
-      "tag": "021N"
+      "tag": "021N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4011"
     },
     "022A/00": {
       "label": "Werktitel und sonstige unterscheidende Merkmale des Werks",
@@ -3396,7 +3414,8 @@
           "repeatable": false
         }
       },
-      "tag": "022A"
+      "tag": "022A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3210"
     },
     "022A/01": {
       "label": "Weiterer Werktitel und sonstige unterscheidende Merkmale",
@@ -3525,7 +3544,8 @@
           "repeatable": false
         }
       },
-      "tag": "022A"
+      "tag": "022A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3211"
     },
     "022S": {
       "label": "Sammlungsvermerk",
@@ -3548,7 +3568,8 @@
           "repeatable": false
         }
       },
-      "tag": "022S"
+      "tag": "022S",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3200"
     },
     "025@": {
       "label": "Ansetzungssachtitel",
@@ -3585,7 +3606,8 @@
           "repeatable": false
         }
       },
-      "tag": "025@"
+      "tag": "025@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3220"
     },
     "026C": {
       "label": "Normierter Zeitschriftenkurztitel",
@@ -3615,7 +3637,8 @@
           "repeatable": false
         }
       },
-      "tag": "026C"
+      "tag": "026C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3232"
     },
     "027A": {
       "label": "Abweichender Titel (Sucheinstieg)",
@@ -3645,7 +3668,8 @@
           "repeatable": false
         }
       },
-      "tag": "027A"
+      "tag": "027A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3260"
     },
     "028A": {
       "label": "Person/Familie als 1. geistiger Schöpfer",
@@ -3801,7 +3825,8 @@
           "repeatable": false
         }
       },
-      "tag": "028A"
+      "tag": "028A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3000"
     },
     "028B/01-02": {
       "label": "2. und weitere Verfasser",
@@ -3923,7 +3948,8 @@
           "repeatable": false
         }
       },
-      "tag": "028B"
+      "tag": "028B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3001-3002"
     },
     "028C": {
       "label": "Person/Familie als 2. und weiterer geistiger Schöpfer, sonstige Personen/Familien, die mit dem Werk in Verbindung stehen, Mitwirkende, Hersteller, Verlage, Vertriebe",
@@ -4051,7 +4077,8 @@
           "repeatable": false
         }
       },
-      "tag": "028C"
+      "tag": "028C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3010"
     },
     "028E": {
       "label": "Interpret",
@@ -4172,7 +4199,8 @@
           "repeatable": false
         }
       },
-      "tag": "028E"
+      "tag": "028E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3030"
     },
     "028G": {
       "label": "Sonstige Person/Familie",
@@ -4307,7 +4335,8 @@
           "repeatable": false
         }
       },
-      "tag": "028G"
+      "tag": "028G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3050"
     },
     "028Z": {
       "label": "Abweichende Namen in Nicht-RDA-Sätzen, Importdaten",
@@ -4393,7 +4422,8 @@
           "repeatable": false
         }
       },
-      "tag": "028Z"
+      "tag": "028Z",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3090"
     },
     "029A": {
       "label": "Körperschaft als 1. geistiger Schöpfer",
@@ -4507,7 +4537,8 @@
           "repeatable": true
         }
       },
-      "tag": "029A"
+      "tag": "029A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3100"
     },
     "029E": {
       "label": "Körperschaft als Interpret",
@@ -4607,7 +4638,8 @@
           "repeatable": true
         }
       },
-      "tag": "029E"
+      "tag": "029E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3140"
     },
     "029F": {
       "label": "Körperschaft als 2. und weiterer geistiger Schöpfer, sonstige Körperschaften, die mit dem Werk in Verbindung stehen, Mitwirkende, Hersteller, Verlage, Vertriebe",
@@ -4714,7 +4746,8 @@
           "repeatable": true
         }
       },
-      "tag": "029F"
+      "tag": "029F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3110"
     },
     "029G": {
       "label": "Sonstige Körperschaft",
@@ -4828,7 +4861,8 @@
           "repeatable": true
         }
       },
-      "tag": "029G"
+      "tag": "029G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3150"
     },
     "030F": {
       "label": "Konferenz",
@@ -4886,7 +4920,8 @@
           "repeatable": false
         }
       },
-      "tag": "030F"
+      "tag": "030F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3160"
     },
     "031@": {
       "label": "Zählung von fortlaufenden Ressourcen",
@@ -4902,7 +4937,8 @@
           "repeatable": false
         }
       },
-      "tag": "031@"
+      "tag": "031@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4025"
     },
     "031A": {
       "label": "Differenzierende Angaben zur Quelle",
@@ -4995,7 +5031,8 @@
           "repeatable": false
         }
       },
-      "tag": "031A"
+      "tag": "031A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4070"
     },
     "031C": {
       "label": "Quellenangaben zu Artikelserien",
@@ -5018,7 +5055,8 @@
           "repeatable": false
         }
       },
-      "tag": "031C"
+      "tag": "031C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4072"
     },
     "031N": {
       "label": "Zählung von fortlaufenden Ressourcen in maschinell interpretierbarer Form",
@@ -5111,7 +5149,8 @@
           "repeatable": true
         }
       },
-      "tag": "031N"
+      "tag": "031N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4024"
     },
     "032@": {
       "label": "Ausgabevermerk",
@@ -5148,7 +5187,8 @@
           "repeatable": false
         }
       },
-      "tag": "032@"
+      "tag": "032@",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4020"
     },
     "032C": {
       "label": "Ausgabevermerk der Reproduktion",
@@ -5178,7 +5218,8 @@
           "repeatable": false
         }
       },
-      "tag": "032C"
+      "tag": "032C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4022"
     },
     "032V": {
       "label": "Sonstige unterscheidende Eigenschaften des Werks",
@@ -5236,7 +5277,8 @@
           "repeatable": true
         }
       },
-      "tag": "032V"
+      "tag": "032V",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3214"
     },
     "032W": {
       "label": "Form des Werks",
@@ -5280,7 +5322,8 @@
           "repeatable": false
         }
       },
-      "tag": "032W"
+      "tag": "032W",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3213"
     },
     "032X": {
       "label": "Besetzung",
@@ -5366,7 +5409,8 @@
           "repeatable": false
         }
       },
-      "tag": "032X"
+      "tag": "032X",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3215"
     },
     "032Y": {
       "label": "Numerische Kennzeichnung eines Musikwerks",
@@ -5417,7 +5461,8 @@
           "repeatable": false
         }
       },
-      "tag": "032Y"
+      "tag": "032Y",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3216"
     },
     "032Z": {
       "label": "Tonart",
@@ -5440,7 +5485,8 @@
           "repeatable": false
         }
       },
-      "tag": "032Z"
+      "tag": "032Z",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=3217"
     },
     "033A": {
       "label": "Veröffentlichungsangabe",
@@ -5498,7 +5544,8 @@
           "repeatable": false
         }
       },
-      "tag": "033A"
+      "tag": "033A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4030"
     },
     "033B/01": {
       "label": "Ort, Datenbankanbieter (Host)",
@@ -5536,7 +5583,8 @@
           "repeatable": true
         }
       },
-      "tag": "033B"
+      "tag": "033B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4031"
     },
     "033B/05": {
       "label": "Weiterer und/oder früherer Verlagsort und Verleger",
@@ -5588,7 +5636,8 @@
           "repeatable": true
         }
       },
-      "tag": "033B"
+      "tag": "033B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4035"
     },
     "033C": {
       "label": "Herstellungsangabe",
@@ -5639,7 +5688,8 @@
           "repeatable": false
         }
       },
-      "tag": "033C"
+      "tag": "033C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4045"
     },
     "033D": {
       "label": "Normierter Ort",
@@ -5697,7 +5747,8 @@
           "repeatable": false
         }
       },
-      "tag": "033D"
+      "tag": "033D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4040"
     },
     "033E": {
       "label": "Vertriebsangabe",
@@ -5748,7 +5799,8 @@
           "repeatable": false
         }
       },
-      "tag": "033E"
+      "tag": "033E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4034"
     },
     "033F": {
       "label": "Entstehungsangabe",
@@ -5799,7 +5851,8 @@
           "repeatable": false
         }
       },
-      "tag": "033F"
+      "tag": "033F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4046"
     },
     "033H": {
       "label": "Verbreitungsort in normierter Form",
@@ -5843,7 +5896,8 @@
           "repeatable": false
         }
       },
-      "tag": "033H"
+      "tag": "033H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4050"
     },
     "033J": {
       "label": "Drucker, Verleger oder Buchhändler (bei Alten Drucken)",
@@ -5943,7 +5997,8 @@
           "repeatable": false
         }
       },
-      "tag": "033J"
+      "tag": "033J",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4043"
     },
     "033N": {
       "label": "Veröffentlichungsangabe der Reproduktion",
@@ -5980,81 +6035,8 @@
           "repeatable": true
         }
       },
-      "tag": "033N"
-    },
-    "033O": {
-      "label": "Ort und Hersteller der Sekundärausgabe",
-      "modified": "2019-03-18T14:12:13",
-      "pica3": "4049",
-      "repeatable": true,
-      "subfields": {
-        "T": {
-          "code": "T",
-          "label": "Feldzuordnung ",
-          "modified": "2019-11-29T13:36:49",
-          "pica3": "$T",
-          "repeatable": false
-        },
-        "U": {
-          "code": "U",
-          "label": "Schriftcode ",
-          "modified": "2020-06-04T08:39:58",
-          "pica3": "$U",
-          "repeatable": false
-        },
-        "n": {
-          "code": "n",
-          "label": "Verlag",
-          "modified": "2020-06-04T08:39:58",
-          "pica3": "$n",
-          "repeatable": true
-        },
-        "p": {
-          "code": "p",
-          "label": "Ort",
-          "modified": "2020-06-04T08:39:58",
-          "pica3": "$p",
-          "repeatable": true
-        }
-      },
-      "tag": "033O"
-    },
-    "033P": {
-      "label": "Urheber der Verfilmung",
-      "modified": "2019-08-13T11:07:56",
-      "pica3": "4067",
-      "repeatable": true,
-      "subfields": {
-        "T": {
-          "code": "T",
-          "label": "Feldzuordnung ",
-          "modified": "2019-11-29T09:14:33",
-          "pica3": "$T",
-          "repeatable": false
-        },
-        "U": {
-          "code": "U",
-          "label": "Schriftcode ",
-          "modified": "2020-06-04T08:39:58",
-          "pica3": "$U",
-          "repeatable": false
-        },
-        "n": {
-          "code": "n",
-          "label": "Verlag",
-          "modified": "2020-06-04T08:39:58",
-          "pica3": "$n",
-          "repeatable": true
-        },
-        "p": {
-          "code": "p",
-          "label": "Ort",
-          "modified": "2020-06-04T08:39:58",
-          "pica3": "$p",
-          "repeatable": true
-        }
-      },
-      "tag": "033P"
+      "tag": "033N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4048"
     },
     "033Q": {
       "label": "Umfang der Reproduktion",
@@ -6084,7 +6066,8 @@
           "repeatable": false
         }
       },
-      "tag": "033Q"
+      "tag": "033Q",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4068"
     },
     "034D": {
       "label": "Umfang",
@@ -6114,7 +6097,8 @@
           "repeatable": false
         }
       },
-      "tag": "034D"
+      "tag": "034D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4060"
     },
     "034I": {
       "label": "Format, Maße",
@@ -6144,7 +6128,8 @@
           "repeatable": false
         }
       },
-      "tag": "034I"
+      "tag": "034I",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4062"
     },
     "034K": {
       "label": "Begleitmaterial",
@@ -6174,7 +6159,8 @@
           "repeatable": false
         }
       },
-      "tag": "034K"
+      "tag": "034K",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4063"
     },
     "034M": {
       "label": "Illustrationsangabe bzw. sonstige physische und technische Angaben",
@@ -6204,7 +6190,8 @@
           "repeatable": false
         }
       },
-      "tag": "034M"
+      "tag": "034M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4061"
     },
     "035E": {
       "label": "Maßstab",
@@ -6304,7 +6291,8 @@
           "repeatable": false
         }
       },
-      "tag": "035E"
+      "tag": "035E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4026"
     },
     "035F": {
       "label": "Projektion",
@@ -6334,7 +6322,8 @@
           "repeatable": false
         }
       },
-      "tag": "035F"
+      "tag": "035F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4027"
     },
     "035G": {
       "label": "Koordinaten",
@@ -6385,7 +6374,8 @@
           "repeatable": false
         }
       },
-      "tag": "035G"
+      "tag": "035G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4028"
     },
     "035H": {
       "label": "Äquinoktium",
@@ -6401,7 +6391,8 @@
           "repeatable": true
         }
       },
-      "tag": "035H"
+      "tag": "035H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4029"
     },
     "036C/00": {
       "label": "Gesamttitel der mehrteiligen Monografie",
@@ -6467,7 +6458,8 @@
           "repeatable": false
         }
       },
-      "tag": "036C"
+      "tag": "036C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4150"
     },
     "036C/01-09": {
       "label": "Untergliederung",
@@ -6540,7 +6532,8 @@
           "repeatable": false
         }
       },
-      "tag": "036C"
+      "tag": "036C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4151-4159"
     },
     "036D": {
       "label": "Verknüpfung zur mehrteiligen Monografie (Überordnung)",
@@ -6612,7 +6605,8 @@
           "repeatable": false
         }
       },
-      "tag": "036D"
+      "tag": "036D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4160"
     },
     "036E/00-09": {
       "label": "Gesamttitel der fortlaufenden Ressource",
@@ -6671,7 +6665,8 @@
           "repeatable": true
         }
       },
-      "tag": "036E"
+      "tag": "036E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4170-4179"
     },
     "036F/00": {
       "label": "Verknüpfung zur fortlaufenden Ressource",
@@ -6730,7 +6725,8 @@
           "repeatable": false
         }
       },
-      "tag": "036F"
+      "tag": "036F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4180-4189"
     },
     "036L/00-09": {
       "label": "Gesamttitel der Reproduktion",
@@ -6789,7 +6785,8 @@
           "repeatable": true
         }
       },
-      "tag": "036L"
+      "tag": "036L",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4110-4119"
     },
     "036M/00-09": {
       "label": "Verknüpfung zum Gesamttitel der Reproduktion",
@@ -6848,7 +6845,8 @@
           "repeatable": false
         }
       },
-      "tag": "036M"
+      "tag": "036M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4120-4129"
     },
     "037A": {
       "label": "Sonstige Anmerkungen",
@@ -6885,7 +6883,8 @@
           "repeatable": false
         }
       },
-      "tag": "037A"
+      "tag": "037A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4201"
     },
     "037B": {
       "label": "Aufzeichnungsort und Aufzeichnungsdatum",
@@ -6915,7 +6914,8 @@
           "repeatable": false
         }
       },
-      "tag": "037B"
+      "tag": "037B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4202"
     },
     "037C": {
       "label": "Hochschulschriftenvermerk",
@@ -6980,7 +6980,8 @@
           "repeatable": false
         }
       },
-      "tag": "037C"
+      "tag": "037C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4204"
     },
     "037F": {
       "label": "Filmspezifische Anmerkungen (Filmgattung/Produktionsland/Produktionsjahr)",
@@ -7010,7 +7011,8 @@
           "repeatable": true
         }
       },
-      "tag": "037F"
+      "tag": "037F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4205"
     },
     "037G": {
       "label": "Anmerkung zur Reproduktion",
@@ -7075,7 +7077,8 @@
           "repeatable": false
         }
       },
-      "tag": "037G"
+      "tag": "037G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4237"
     },
     "037H": {
       "label": "Technische Angabe zum Digitalisat",
@@ -7259,7 +7262,8 @@
           "repeatable": false
         }
       },
-      "tag": "037H"
+      "tag": "037H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4238"
     },
     "037K": {
       "label": "Incipit der Unterlage (Nachlasserschließung)",
@@ -7275,7 +7279,8 @@
           "repeatable": false
         }
       },
-      "tag": "037K"
+      "tag": "037K",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4270"
     },
     "037L": {
       "label": "Einheitsincipit der Unterlage (Nachlasserschließung)",
@@ -7291,7 +7296,8 @@
           "repeatable": false
         }
       },
-      "tag": "037L"
+      "tag": "037L",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4271"
     },
     "037M": {
       "label": "Explicit der Unterlage",
@@ -7307,7 +7313,8 @@
           "repeatable": false
         }
       },
-      "tag": "037M"
+      "tag": "037M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4272"
     },
     "037N": {
       "label": "Angaben zur äußeren Unterlage (Nachlasserschließung)",
@@ -7351,7 +7358,8 @@
           "repeatable": false
         }
       },
-      "tag": "037N"
+      "tag": "037N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4275"
     },
     "037O": {
       "label": "Bezugswerke (Nachlasserschließung)",
@@ -7381,7 +7389,8 @@
           "repeatable": false
         }
       },
-      "tag": "037O"
+      "tag": "037O",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4276"
     },
     "037P": {
       "label": "Weitere Informationen zur Handschrift",
@@ -7418,7 +7427,8 @@
           "repeatable": true
         }
       },
-      "tag": "037P"
+      "tag": "037P",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4277"
     },
     "037Q": {
       "label": "Beschreibung des Einbands",
@@ -7532,7 +7542,8 @@
           "repeatable": false
         }
       },
-      "tag": "037Q"
+      "tag": "037Q",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4278"
     },
     "037R": {
       "label": "Buchschmuck (Druckermarken, Vignetten, Zierleisten etc.)",
@@ -7618,7 +7629,8 @@
           "repeatable": false
         }
       },
-      "tag": "037R"
+      "tag": "037R",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4279"
     },
     "038L": {
       "label": "Umlenkfeld",
@@ -7669,7 +7681,8 @@
           "repeatable": false
         }
       },
-      "tag": "038L"
+      "tag": "038L",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=1698"
     },
     "039B": {
       "label": "Beziehungen zur größeren Einheit",
@@ -7810,7 +7823,8 @@
           "repeatable": false
         }
       },
-      "tag": "039B"
+      "tag": "039B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4241"
     },
     "039C": {
       "label": "Beziehungen zur kleineren Einheit",
@@ -7944,7 +7958,8 @@
           "repeatable": false
         }
       },
-      "tag": "039C"
+      "tag": "039C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4242"
     },
     "039D": {
       "label": "Beziehungen auf Manifestationsebene",
@@ -8079,7 +8094,8 @@
           "repeatable": false
         }
       },
-      "tag": "039D"
+      "tag": "039D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4243"
     },
     "039E": {
       "label": "Vorgänger-Nachfolge-Beziehungen auf Werkebene",
@@ -8221,7 +8237,8 @@
           "repeatable": false
         }
       },
-      "tag": "039E"
+      "tag": "039E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4244"
     },
     "039H": {
       "label": "Beziehungen zur Reproduktion in gleicher physischer Form",
@@ -8356,7 +8373,8 @@
           "repeatable": false
         }
       },
-      "tag": "039H"
+      "tag": "039H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4255"
     },
     "039I": {
       "label": "Beziehungen zur Reproduktion in anderer physischer Form",
@@ -8505,7 +8523,8 @@
           "repeatable": false
         }
       },
-      "tag": "039I"
+      "tag": "039I",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4256"
     },
     "039M": {
       "label": "Beziehungen zwischen Sprachausgaben (Expressionsebene)",
@@ -8640,7 +8659,8 @@
           "repeatable": false
         }
       },
-      "tag": "039M"
+      "tag": "039M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4248"
     },
     "039N": {
       "label": "Weitere Beziehungen",
@@ -8775,7 +8795,8 @@
           "repeatable": false
         }
       },
-      "tag": "039N"
+      "tag": "039N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4249"
     },
     "039P": {
       "label": "Themenbeziehungen (Beziehung zu der Ressource, die beschrieben wird)",
@@ -8910,7 +8931,8 @@
           "repeatable": false
         }
       },
-      "tag": "039P"
+      "tag": "039P",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4261"
     },
     "039Q": {
       "label": "Themenbeziehungen (Beziehung zu einer Beschreibung über die Ressource)",
@@ -9045,7 +9067,8 @@
           "repeatable": false
         }
       },
-      "tag": "039Q"
+      "tag": "039Q",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4262"
     },
     "039S": {
       "label": "Titelkonkordanzen",
@@ -9151,7 +9174,8 @@
           "repeatable": false
         }
       },
-      "tag": "039S"
+      "tag": "039S",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4245"
     },
     "041A/00-99": {
       "label": "Schlagwortfolgen (DNB und Verbünde)",
@@ -9210,11 +9234,12 @@
           "repeatable": false
         }
       },
-      "tag": "041A"
+      "tag": "041A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5100-5199"
     },
     "044A": {
       "label": "LoC Subject Headings",
-      "modified": "2019-02-07T11:48:20",
+      "modified": "2023-01-19T09:19:33",
       "pica3": "5500",
       "repeatable": true,
       "subfields": {
@@ -9408,11 +9433,12 @@
           "repeatable": true
         }
       },
-      "tag": "044A"
+      "tag": "044A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5500"
     },
     "044C": {
       "label": "Medical Subject Headings (MeSH)",
-      "modified": "2019-02-07T12:20:39",
+      "modified": "2023-01-19T09:19:59",
       "pica3": "5510",
       "repeatable": true,
       "subfields": {
@@ -9606,7 +9632,8 @@
           "repeatable": true
         }
       },
-      "tag": "044C"
+      "tag": "044C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5510"
     },
     "044H": {
       "label": "Erschließung von Musikalien nach Besetzung und Form/Gattung",
@@ -9699,7 +9726,8 @@
           "repeatable": true
         }
       },
-      "tag": "044H"
+      "tag": "044H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5590"
     },
     "044K/00-09": {
       "label": "Schlagwortfolgen (GBV, SWB, K10plus)",
@@ -9772,7 +9800,8 @@
           "repeatable": false
         }
       },
-      "tag": "044K"
+      "tag": "044K",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5550-5559"
     },
     "044L/00-09": {
       "label": "Einzelschlagwörter (Projekte)",
@@ -9858,7 +9887,8 @@
           "repeatable": false
         }
       },
-      "tag": "044L"
+      "tag": "044L",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5580-5589"
     },
     "044N": {
       "label": "Schlagwörter aus einem Thesaurus und freie Schlagwörter",
@@ -9904,12 +9934,13 @@
         "i": {
           "code": "i",
           "label": "Thesaurus bzw. Kennzeichnung von freien Schlagwörtern",
-          "modified": "2022-11-16T11:45:35",
+          "modified": "2023-01-19T09:23:32",
           "pica3": "[...]",
           "repeatable": false
         }
       },
-      "tag": "044N"
+      "tag": "044N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5520"
     },
     "044S": {
       "label": "Gattungsbegriffe bei Alten Drucken",
@@ -9953,7 +9984,8 @@
           "repeatable": false
         }
       },
-      "tag": "044S"
+      "tag": "044S",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5570"
     },
     "044Z/00-99": {
       "label": "Lokale Schlagwörter auf bibliografischer Ebene",
@@ -9998,7 +10030,8 @@
           "repeatable": false
         }
       },
-      "tag": "044Z"
+      "tag": "044Z",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=6400-6499"
     },
     "045A": {
       "label": "LCC-Notation",
@@ -10070,7 +10103,8 @@
           "repeatable": false
         }
       },
-      "tag": "045A"
+      "tag": "045A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5030"
     },
     "045B/00": {
       "label": "Allgemeine Systematik für Bibliotheken (ASB)",
@@ -10094,7 +10128,8 @@
           "repeatable": true
         }
       },
-      "tag": "045B"
+      "tag": "045B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5020"
     },
     "045B/01": {
       "label": "Systematik der Stadtbibliothek Duisburg (SSD)",
@@ -10118,7 +10153,8 @@
           "repeatable": true
         }
       },
-      "tag": "045B"
+      "tag": "045B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5021"
     },
     "045B/02": {
       "label": "Systematik für Bibliotheken (SfB)",
@@ -10142,7 +10178,8 @@
           "repeatable": true
         }
       },
-      "tag": "045B"
+      "tag": "045B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5022"
     },
     "045B/03": {
       "label": "Klassifikation für Allgemeinbibliotheken (KAB)",
@@ -10166,7 +10203,8 @@
           "repeatable": true
         }
       },
-      "tag": "045B"
+      "tag": "045B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5023"
     },
     "045B/04": {
       "label": "Systematiken der ekz",
@@ -10190,7 +10228,8 @@
           "repeatable": true
         }
       },
-      "tag": "045B"
+      "tag": "045B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5024"
     },
     "045B/05": {
       "label": "Gattungsbegriffe (DNB)",
@@ -10214,7 +10253,8 @@
           "repeatable": false
         }
       },
-      "tag": "045B"
+      "tag": "045B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5025"
     },
     "045C": {
       "label": "Klassifikation der National Library of Medicine (NLM)",
@@ -10286,7 +10326,8 @@
           "repeatable": false
         }
       },
-      "tag": "045C"
+      "tag": "045C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5040"
     },
     "045D/00-48": {
       "label": "STW-Schlagwörter",
@@ -10331,7 +10372,8 @@
           "repeatable": false
         }
       },
-      "tag": "045D"
+      "tag": "045D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5200-5248"
     },
     "045D/49": {
       "label": "ZBW-Schlagwörter - Veröffentlichungsart",
@@ -10362,7 +10404,8 @@
           "repeatable": false
         }
       },
-      "tag": "045D"
+      "tag": "045D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5249"
     },
     "045D/50": {
       "label": "Vorläufige Schlagwörter (STW)",
@@ -10400,7 +10443,8 @@
           "repeatable": true
         }
       },
-      "tag": "045D"
+      "tag": "045D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5250"
     },
     "045D/60": {
       "label": "FIV-Schlagwörter (Themen)",
@@ -10445,7 +10489,8 @@
           "repeatable": false
         }
       },
-      "tag": "045D"
+      "tag": "045D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5260-5260"
     },
     "045D/70": {
       "label": "FIV-Schlagwörter (Aspekte)",
@@ -10490,7 +10535,8 @@
           "repeatable": false
         }
       },
-      "tag": "045D"
+      "tag": "045D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5270-5270"
     },
     "045E": {
       "label": "Sachgruppen der Deutschen Nationalbibliografie bis 2003",
@@ -10513,7 +10559,8 @@
           "repeatable": true
         }
       },
-      "tag": "045E"
+      "tag": "045E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5050"
     },
     "045F": {
       "label": "DDC-Notation",
@@ -10524,7 +10571,7 @@
         "A": {
           "code": "A",
           "label": "Quelle",
-          "modified": "2022-03-07T12:51:21",
+          "modified": "2023-01-20T09:07:03",
           "pica3": "$A",
           "repeatable": true
         },
@@ -10556,6 +10603,13 @@
           "pica3": "$k",
           "repeatable": false
         },
+        "u": {
+          "code": "u",
+          "label": "URL",
+          "modified": "2023-01-20T09:06:55",
+          "pica3": "$u",
+          "repeatable": false
+        },
         "v": {
           "code": "v",
           "label": "Datum der Generierung",
@@ -10564,7 +10618,8 @@
           "repeatable": false
         }
       },
-      "tag": "045F"
+      "tag": "045F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5010"
     },
     "045G": {
       "label": "Sachgruppen der Deutschen Nationalbibliografie ab 2004",
@@ -10601,7 +10656,8 @@
           "repeatable": false
         }
       },
-      "tag": "045G"
+      "tag": "045G",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5051"
     },
     "045H/00-99": {
       "label": "DDC-Notation: Vollständige Notation",
@@ -10716,7 +10772,8 @@
           "repeatable": true
         }
       },
-      "tag": "045H"
+      "tag": "045H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5400-5499"
     },
     "045M/00-99": {
       "label": "Lokale Notationen auf bibliografischer Ebene",
@@ -10740,7 +10797,8 @@
           "repeatable": false
         }
       },
-      "tag": "045M"
+      "tag": "045M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=6300-6399"
     },
     "045N": {
       "label": "FIV-Regionalklassifikation",
@@ -10791,7 +10849,8 @@
           "repeatable": false
         }
       },
-      "tag": "045N"
+      "tag": "045N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5070-5070"
     },
     "045N/01": {
       "label": "FIV-Sachklassifikation",
@@ -10843,7 +10902,8 @@
           "repeatable": false
         }
       },
-      "tag": "045N"
+      "tag": "045N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5071-5071"
     },
     "045N/02": {
       "label": "Sonstige Notation des FIV",
@@ -10895,7 +10955,8 @@
           "repeatable": false
         }
       },
-      "tag": "045N"
+      "tag": "045N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5072-5072"
     },
     "045Q/01": {
       "label": "Basisklassifikation",
@@ -10940,7 +11001,8 @@
           "repeatable": false
         }
       },
-      "tag": "045Q"
+      "tag": "045Q",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5301"
     },
     "045R": {
       "label": "Regensburger Verbundklassifikation (RVK)",
@@ -10998,7 +11060,8 @@
           "repeatable": false
         }
       },
-      "tag": "045R"
+      "tag": "045R",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5090"
     },
     "045S": {
       "label": "Deutsche Bibliotheksstatistik (DBS)",
@@ -11014,7 +11077,8 @@
           "repeatable": true
         }
       },
-      "tag": "045S"
+      "tag": "045S",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5055"
     },
     "045T": {
       "label": "Nicht mehr gültige Notationen der Regensburger Verbundklassifikation (RVK)",
@@ -11058,7 +11122,8 @@
           "repeatable": false
         }
       },
-      "tag": "045T"
+      "tag": "045T",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5091"
     },
     "045V": {
       "label": "SSG-Nummer/FID-Kennzeichen",
@@ -11095,7 +11160,8 @@
           "repeatable": false
         }
       },
-      "tag": "045V"
+      "tag": "045V",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5056"
     },
     "045W": {
       "label": "SSG-Angabe für thematische OLC-Ausschnitte",
@@ -11118,7 +11184,8 @@
           "repeatable": true
         }
       },
-      "tag": "045W"
+      "tag": "045W",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5057"
     },
     "045X": {
       "label": "Notation eines Klassifikationssystems",
@@ -11211,7 +11278,8 @@
           "repeatable": false
         }
       },
-      "tag": "045X"
+      "tag": "045X",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5060"
     },
     "045Y": {
       "label": "SSG-Angabe für Fachkataloge",
@@ -11234,7 +11302,8 @@
           "repeatable": true
         }
       },
-      "tag": "045Y"
+      "tag": "045Y",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=5058"
     },
     "046A": {
       "label": "Einheitssachtitel des beigefügten oder kommentierten Werkes",
@@ -11271,7 +11340,8 @@
           "repeatable": false
         }
       },
-      "tag": "046A"
+      "tag": "046A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4210"
     },
     "046C": {
       "label": "Abweichender Titel",
@@ -11308,7 +11378,8 @@
           "repeatable": false
         }
       },
-      "tag": "046C"
+      "tag": "046C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4212"
     },
     "046D": {
       "label": "Frühere/frühester Haupttitel (nur für fortlaufende und integrierende Ressourcen)",
@@ -11352,7 +11423,8 @@
           "repeatable": false
         }
       },
-      "tag": "046D"
+      "tag": "046D",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4213"
     },
     "046E": {
       "label": "Angabe der Quelle der Aufnahme",
@@ -11382,7 +11454,8 @@
           "repeatable": false
         }
       },
-      "tag": "046E"
+      "tag": "046E",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4214"
     },
     "046H": {
       "label": "Anmerkung zur Veröffentlichungsangabe und zum Copyright-Datum",
@@ -11419,11 +11492,12 @@
           "repeatable": false
         }
       },
-      "tag": "046H"
+      "tag": "046H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4217"
     },
     "046K": {
       "label": "Voraussichtlicher Erscheinungstermin",
-      "modified": "2020-06-04T11:35:31",
+      "modified": "2022-12-13T10:46:12",
       "pica3": "4220",
       "repeatable": false,
       "subfields": {
@@ -11435,7 +11509,8 @@
           "repeatable": false
         }
       },
-      "tag": "046K"
+      "tag": "046K",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4220"
     },
     "046L": {
       "label": "Angaben über Sprache und Schrift der Expression",
@@ -11465,7 +11540,8 @@
           "repeatable": false
         }
       },
-      "tag": "046L"
+      "tag": "046L",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4221"
     },
     "046M": {
       "label": "Angaben zu enthaltenen unselbstständigen Werken",
@@ -11558,7 +11634,8 @@
           "repeatable": false
         }
       },
-      "tag": "046M"
+      "tag": "046M",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4222"
     },
     "046N": {
       "label": "Anmerkungen zu Interpreten, Ausführenden, Erzählern und/oder Präsentatoren",
@@ -11588,7 +11665,8 @@
           "repeatable": false
         }
       },
-      "tag": "046N"
+      "tag": "046N",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4223"
     },
     "046P": {
       "label": "Anmerkung zur Zählung von fortlaufenden Ressourcen",
@@ -11618,7 +11696,8 @@
           "repeatable": false
         }
       },
-      "tag": "046P"
+      "tag": "046P",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4225"
     },
     "046U": {
       "label": "Altersfreigabe von Filmen und Computerspielen",
@@ -11634,7 +11713,8 @@
           "repeatable": false
         }
       },
-      "tag": "046U"
+      "tag": "046U",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4206"
     },
     "046V": {
       "label": "Künstlerische und/oder technische Angabe",
@@ -11659,12 +11739,13 @@
         "a": {
           "code": "a",
           "label": "Künstlerische und/oder technische Angabe",
-          "modified": "2020-06-04T08:39:58",
+          "modified": "2023-01-16T14:39:47",
           "pica3": "",
           "repeatable": false
         }
       },
-      "tag": "046V"
+      "tag": "046V",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4209"
     },
     "046W": {
       "label": "Kommentarfeld",
@@ -11680,7 +11761,8 @@
           "repeatable": false
         }
       },
-      "tag": "046W"
+      "tag": "046W",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=0999"
     },
     "046X": {
       "label": "Bestandsschutzmaßnahmen und (Langzeit-)Archivierung",
@@ -11794,7 +11876,8 @@
           "repeatable": false
         }
       },
-      "tag": "046X"
+      "tag": "046X",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4233"
     },
     "047A": {
       "label": "Allgemeiner Bearbeitungshinweis",
@@ -11810,7 +11893,8 @@
           "repeatable": false
         }
       },
-      "tag": "047A"
+      "tag": "047A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4700"
     },
     "047B": {
       "label": "Bearbeitungshinweis zur Titelaufnahme aus Fremddaten",
@@ -11826,7 +11910,8 @@
           "repeatable": false
         }
       },
-      "tag": "047B"
+      "tag": "047B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4701"
     },
     "047C": {
       "label": "Zusätzliche Sucheinstiege",
@@ -11863,7 +11948,8 @@
           "repeatable": false
         }
       },
-      "tag": "047C"
+      "tag": "047C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4200"
     },
     "047F": {
       "label": "Statistikfeld aus der Broadcast-Übernahme / Parkfeld für Altdaten",
@@ -11886,7 +11972,8 @@
           "repeatable": false
         }
       },
-      "tag": "047F"
+      "tag": "047F",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=8910"
     },
     "047I": {
       "label": "Inhaltliche Zusammenfassung",
@@ -11916,7 +12003,8 @@
           "repeatable": false
         }
       },
-      "tag": "047I"
+      "tag": "047I",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4207"
     },
     "047P": {
       "label": "Zusammenfassende Register",
@@ -11946,7 +12034,8 @@
           "repeatable": false
         }
       },
-      "tag": "047P"
+      "tag": "047P",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4203"
     },
     "048H": {
       "label": "Systemvoraussetzungen für elektronische Ressourcen",
@@ -11962,7 +12051,8 @@
           "repeatable": false
         }
       },
-      "tag": "048H"
+      "tag": "048H",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=4251"
     },
     "089A": {
       "label": "Verknüpfungsnummer des zu korrigierenden Satzes",
@@ -11985,7 +12075,8 @@
           "repeatable": false
         }
       },
-      "tag": "089A"
+      "tag": "089A",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=8900"
     },
     "089B": {
       "label": "Datum und Empfänger des Mailboxsatzes",
@@ -12008,7 +12099,8 @@
           "repeatable": true
         }
       },
-      "tag": "089B"
+      "tag": "089B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=8901"
     },
     "089C": {
       "label": "Mitteilungstext",
@@ -12024,7 +12116,8 @@
           "repeatable": false
         }
       },
-      "tag": "089C"
+      "tag": "089C",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=8902"
     },
     "091O/00": {
       "label": "Online-Profildienst: Besitzkennzeichen zur Selektion",
@@ -12041,7 +12134,8 @@
           "repeatable": false
         }
       },
-      "tag": "091O"
+      "tag": "091O",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=9600"
     },
     "091O/04": {
       "label": "Online-Profildienst: Herkunftsangaben",
@@ -12072,7 +12166,8 @@
           "repeatable": true
         }
       },
-      "tag": "091O"
+      "tag": "091O",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=9604"
     },
     "091O/05": {
       "label": "Lieferantendatenimport/Online-Profildienst: Erwerbungsdaten",
@@ -12117,7 +12212,8 @@
           "repeatable": false
         }
       },
-      "tag": "091O"
+      "tag": "091O",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=9605"
     },
     "091O/28": {
       "label": "Online-Profildienst: Preisangaben",
@@ -12148,7 +12244,8 @@
           "repeatable": false
         }
       },
-      "tag": "091O"
+      "tag": "091O",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=9628"
     },
     "091O/99": {
       "label": "Online-Profildienst: Anzeige",
@@ -12172,7 +12269,8 @@
           "repeatable": false
         }
       },
-      "tag": "091O"
+      "tag": "091O",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=9699"
     },
     "092B": {
       "label": "Provenienzangaben",
@@ -12286,7 +12384,8 @@
           "repeatable": false
         }
       },
-      "tag": "092B"
+      "tag": "092B",
+      "url": "https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val=9100"
     }
   },
   "language": "de",

--- a/src/main/resources/pica/update-avram-k10plus-title.sh
+++ b/src/main/resources/pica/update-avram-k10plus-title.sh
@@ -7,5 +7,6 @@ TIMESTAMP=$(date +"%Y-%m-%d")
 curl "https://format.k10plus.de/avram.pl?profile=k10plus-title" \
     | jq -S '(.fields[]|select(.subfields.U and .subfields.T)).repeatable=true' \
     | jq -S '(.fields[]|select(.occurrence=="00")).occurrence=null' \
+    | jq -S '.fields|=map_values(.url="https://format.k10plus.de/k10plushelp.pl?cmd=kat&katalog=Standard&val="+.pica3)' \
     > avram-k10plus-title-$TIMESTAMP.json
 


### PR DESCRIPTION
As found in https://github.com/pkiraly/metadata-qa-marc-web/issues/64 the Avram Schema lacks field `url`. This commit adds a hack to patch the Avram Schema. The issue should better be solved on the backend in format.k10plus.de nevertheless.